### PR TITLE
requirement layout and versions changes

### DIFF
--- a/contrib/INSTALL
+++ b/contrib/INSTALL
@@ -2,12 +2,12 @@
 Packages needed:
  lame libboost-dev libsamplerate-dev libicu-dev = demosauce
 
- pil (python imaging library) - check that libjpeg and libzlib is installed, otherwise you will miss jpeg / png support
+ pillow (python imaging library) - check that libjpeg and libzlib is installed, otherwise you will miss jpeg / png support
 
 Create python virtual environment:
  Install pip (python package install program)
  Install virtualenv (can use "pip install virtualenv" if you want)
- To ceate virtual env : pip install -E demovibesenv -U -r demovibes/contrib/requirements.txt
+ To create virtual env : pip install -E demovibesenv -U -r demovibes/requirements/local.txt
  To activate virt env : source demovibesenv/bin/activate
 
 Look over / change settings

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ South==0.7.3
 Whoosh==2.3
 django-extensions==0.5
 django-haystack==1.2.6
--e git+https://gitlab.com/zeograd/django-tagging-fork.git#egg=django_tagging_fork
+-e git+http://git.gitorious.org/demovibes/django-tagging-fork.git#egg=django_tagging_fork
 
 # python-memcached==1.47
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,17 +1,19 @@
 django-authopenid==1.0.1
-Django==1.3
+Django==1.3.7
 Jinja2==2.5.5
-PIL==1.1.7
+# PIL==1.1.6
+Pillow==1.7.8
 South==0.7.3
 Whoosh==2.3
 django-extensions==0.5
 django-haystack==1.2.6
-#django-tagging==0.3.1
 -e git+http://git.gitorious.org/demovibes/django-tagging-fork.git#egg=django_tagging_fork
-python-memcached==1.47
+
+# python-memcached==1.47
+
 python-openid==2.2.5
 wsgiref==0.1.2
 flup==1.0.3.dev-20110405
-MySQL-python==1.2.3
+# MySQL-python==1.2.3
 django-wsgiserver==0.6.9
 pika==0.5.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ South==0.7.3
 Whoosh==2.3
 django-extensions==0.5
 django-haystack==1.2.6
--e git+http://git.gitorious.org/demovibes/django-tagging-fork.git#egg=django_tagging_fork
+-e git+https://gitlab.com/zeograd/django-tagging-fork.git#egg=django_tagging_fork
 
 # python-memcached==1.47
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,6 +14,5 @@ django-haystack==1.2.6
 python-openid==2.2.5
 wsgiref==0.1.2
 flup==1.0.3.dev-20110405
-# MySQL-python==1.2.3
 django-wsgiserver==0.6.9
 pika==0.5.2

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,0 +1,2 @@
+-r base.txt
+

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,0 +1,3 @@
+-r base.txt
+
+MySQL-python==1.2.3


### PR DESCRIPTION
monolithic requirements.txt in a documentation directory
doesn't follow the "one true way" django recommendations
(cf Kaplan-moss' talk at OSCON 2011).
This pull request propose to split and move it, as well
as update minimally the versions of requirements to be
installable as of today (2016-02-05).