### PR TITLE
Fix django-tagging-fork URL

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ South==0.7.3
 Whoosh==2.3
 django-extensions==0.5
 django-haystack==1.2.6
--e git+http://git.gitorious.org/demovibes/django-tagging-fork.git#egg=django_tagging_fork
+-e git+https://github.com/arabek/django-tagging-fork.git#egg=django_tagging_fork
 
 # python-memcached==1.47
 


### PR DESCRIPTION
With this change one can use pip to install the dependencies.