### PR TITLE
Attempt to improve AJAX event polling reliability

### DIFF
--- a/demovibes/webview/ajax_views.py
+++ b/demovibes/webview/ajax_views.py
@@ -97,18 +97,16 @@ def ping(request, event_id):
     return HttpResponseRedirect("/demovibes/ajax/monitor/%s/%s" % (event_id, GET_UID))
 
 def monitor(request, event_id):
-    for x in range(30):
-        R = AjaxEvent.objects.filter(id__gt=event_id).order_by('id')
-        if R:
-            entries = list()
-            for event in R:
-                if event.user == None or event.user == request.user:
-                    if not str(event.event) in entries:
-                        entries.append(str(event.event))
-            ajaxid = R.order_by('-id')[0].id + 1
-            return render_to_response('webview/js/manager.html', \
-                { 'events' : entries, 'id' : ajaxid },  context_instance=RequestContext(request))
-        time.sleep(1)
+    R = AjaxEvent.objects.filter(id__gt=event_id).order_by('id')
+    if R:
+        entries = list()
+        for event in R:
+            if event.user == None or event.user == request.user:
+                if not str(event.event) in entries:
+                    entries.append(str(event.event))
+        ajaxid = R.order_by('-id')[0].id
+        return render_to_response('webview/js/manager.html', \
+            { 'events' : entries, 'id' : ajaxid },  context_instance=RequestContext(request))
     return HttpResponse("")
 
 

--- a/static/js/dobject.js
+++ b/static/js/dobject.js
@@ -4,6 +4,7 @@ var ajaxmonitorrequest=false;
 var userIdleTime = 0;
 var updateThrottled = false;
 var updateTimer;
+var randBoost = 1000;
 // Every second.
 var successDelay = defaultSuccessDelay = 1000;
 var throttledSuccessDelay = 240000;
@@ -116,8 +117,9 @@ function ajaxmonitorupdate(req) {
         }
         ajaxmonitorrequest=false;
         applyHooks();
+        var randInt = Math.floor((Math.random()*randBoost));
         updateStatus(false);
-        startAjax(successDelay); // we get a nice return ask again right away
+        startAjax(successDelay + randInt); // we get a nice return ask again right away
 }
 
 function updateVotes(data) {

--- a/static/js/dobject.js
+++ b/static/js/dobject.js
@@ -4,8 +4,8 @@ var ajaxmonitorrequest=false;
 var userIdleTime = 0;
 var updateThrottled = false;
 var updateTimer;
-var randBoost = 1000;
-var successDelay = defaultSuccessDelay = 100;
+// Every second.
+var successDelay = defaultSuccessDelay = 1000;
 var throttledSuccessDelay = 240000;
 var userIdleLimit = 600;
 
@@ -30,6 +30,8 @@ function idleTicker () {
 
 function apf(url, form) {
     $.post(url, $(form).serialize());
+    // Update the oneliner immediately.
+    ajaxmonitorspawn();
     return false;
 }
 
@@ -115,9 +117,8 @@ function ajaxmonitorupdate(req) {
         }
         ajaxmonitorrequest=false;
         applyHooks();
-        var randInt = Math.floor((Math.random()*randBoost));
         updateStatus(false);
-        startAjax(successDelay + randInt); // we get a nice return ask again right away
+        startAjax(successDelay); // we get a nice return ask again right away
 }
 
 function updateVotes(data) {

--- a/static/js/dobject.js
+++ b/static/js/dobject.js
@@ -29,9 +29,8 @@ function idleTicker () {
 }
 
 function apf(url, form) {
-    $.post(url, $(form).serialize());
     // Update the oneliner immediately.
-    ajaxmonitorspawn();
+    $.post(url, $(form).serialize(), ajaxmonitorspawn);
     return false;
 }
 


### PR DESCRIPTION
I've seen "Currently Playing" get stuck on 0:00 and the server seems to not respond with a valid ajax id. This pull request attempts to resolve that issue, although my demovibes installation is not setup with a streamer so I have only tested it with the oneliner.

Browsers poll for events every second instead of waiting for the server to respond to an idle request. Also, send the browser the most recent ajax id instead of adding one.

I'm using ``UWSGI_EVENT_SERVER = None`` in settings_local.py.

It looks like terrasque wasn't so sure about commit f86b696.