### PR TITLE
The event handler returns immediately if there are no events instead of long polling.

### DIFF
--- a/uwsgi_events/uwsgi-events.xml
+++ b/uwsgi_events/uwsgi-events.xml
@@ -2,8 +2,10 @@
   <socket>127.0.0.1:3032</socket>
   <module>uwsgi_eventhandler</module>
   <master/>
-  <async>1500</async>
-  <ugreen/>
+  <!-- Don't increase this unless you rewrite the server. -->
+  <processes>1</processes>
+  <!-- Don't increase this unless you add locking around reading and writing events. -->
+  <threads>1</threads>
   <disable-logging/>
   <daemonize>/tmp/demovibes-events-uwsgi.log</daemonize>
   <pidfile>/tmp/demovibes-events-uwsgi.pid</pidfile>

--- a/uwsgi_events/uwsgi_eventhandler.py
+++ b/uwsgi_events/uwsgi_eventhandler.py
@@ -4,8 +4,6 @@ import bottle
 import pickle
 import random
 
-import threading
-LOCK = threading.Lock()
 import hashlib
 
 try:
@@ -34,11 +32,8 @@ def http_event_receiver():
     return "OK"
 
 def event_receiver(obj, id):
-    LOCK.acquire()
     global event
     event = obj
-    uwsgi.green_unpause_all()
-    LOCK.release()
 
 uwsgi.message_manager_marshal = event_receiver
 
@@ -51,8 +46,10 @@ def handler(id):
         if hash != sign:
             userid = None
     id = int(id)
+    
     if not event or event[1] <= id:
-        uwsgi.green_pause(50 + random.randint(0,20) ) #Try to stop all from being "done" and re-request at the same time
+      yield ""
+      return
     myevent = event
     eventid = myevent[1]
     levent = [x[1] for x in myevent[0] if x[0] > id and (x[2] == "N" or (userid and x[2] == int(userid)))]


### PR DESCRIPTION
I made the event handler synchronous instead of asynchronous and disabled long polling. Perhaps this will solve the problem of AJAX requests taking 40 seconds or more to return.

Side note: Currently AJAX requests go through Django before being redirected to the event handler. This limits the usefulness of the event handler as a cache.

A benchmark to the event handler directly:
```
$ wrk -c 50 -d 30 -t 1 "http://localhost:8080/demovibes/ajax/monitor/12524738/"
Running 30s test @ http://localhost:8080/demovibes/ajax/monitor/12524738/
  1 threads and 50 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     5.44ms    2.05ms  37.11ms   86.86%
    Req/Sec     9.37k     1.97k   12.79k    61.33%
  279707 requests in 30.01s, 73.08MB read
Requests/sec:   9319.16
Transfer/sec:      2.43MB
```

A benchmark through Django:
```
$ wrk -c 50 -d 30 -t 1 "http://localhost:8080/demovibes/ajax/ping/12524738/"
Running 30s test @ http://localhost:8080/demovibes/ajax/ping/12524738/
  1 threads and 50 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    77.99ms   49.61ms 352.94ms   77.12%
    Req/Sec   219.18    106.05   646.00     76.33%
  6554 requests in 30.02s, 1.67MB read
  Socket errors: connect 0, read 0, write 0, timeout 173
Requests/sec:    218.29
Transfer/sec:     56.91KB
```