### PR TITLE
Keep private message subjects shorter when replying

### DIFF
--- a/demovibes/webview/templatetags/dv_extend.py
+++ b/demovibes/webview/templatetags/dv_extend.py
@@ -737,6 +737,43 @@ def get_unread_count(user):
         return ""
     return "(%s)" % nr
 
+
+def get_pm_subject_suggestion(original_subject):
+    original_subject = original_subject.lstrip()
+    s = original_subject.lower()
+
+    # First reply or reply in classic subject format?
+    marker = 're:'
+    if s.startswith(marker):
+        reply_count = 2
+
+        # Condense any "RE: RE: RE: " occurrences from classic subject format
+        marker_with_space = 're: '
+        index = marker_with_space_len = len(marker_with_space)
+        while s.startswith(marker_with_space, index):
+            reply_count += 1
+            index += marker_with_space_len
+
+        index = len(marker) if (reply_count == 2) else index - 1
+
+        return 'Re[{0}]:{1}'.format(reply_count, original_subject[index:])
+
+    # Subsequent replies?
+    begin_marker = 're['
+    end_marker = ']:'
+    index = s.find(end_marker)
+    if index != -1 and s.startswith(begin_marker):
+        reply_count = s[len(begin_marker):index]
+
+        if reply_count.isdigit():
+            return 'Re[{0}]:{1}'.format(
+                int(reply_count) + 1,
+                original_subject[index + len(end_marker):])
+
+    # In all other cases consider this the first reply to a new message.
+    return 'Re: ' + original_subject
+
+
 class GetInboxNode(template.Node):
     def __init__(self, user):
         self.user = user

--- a/templates/jinja/global/webview/view_pm.html
+++ b/templates/jinja/global/webview/view_pm.html
@@ -14,6 +14,6 @@
     </div>
 </div>
 
-<a href="{{ url("dv-inbox") }}">{{ gettext("Back To Inbox") }}</a> | <a href="{{ url("dv-send_pm") }}?to={{ pm.sender|e }}&amp;title=RE: {{ pm.subject|e }}">{{ gettext("Send Reply") }}</a>
+<a href="{{ url("dv-inbox") }}">{{ gettext("Back To Inbox") }}</a> | <a href="{{ url("dv-send_pm") }}?to={{ pm.sender|e }}&amp;title={{ dv.get_pm_subject_suggestion(pm.subject|e) }}">{{ gettext("Send Reply") }}</a>
 {% endblock %}
 


### PR DESCRIPTION
Instead of prepending each new reply with "RE: " use "Re[x]: " where x
is an increasing number (2+).

Also condense any existing 1+ "RE: " parts into a single "Re[x]: ".